### PR TITLE
Portal-based component binding, lazy load components, test for bootstrap

### DIFF
--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -26,7 +26,7 @@ jobs:
           npm run bootstrap
 
       - name: Bundle
-        run: npm run bundle
+        run: NODE_ENV=production npm run bundle
         working-directory: html
 
       - name: Upload Assets

--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -2,7 +2,7 @@ name: CDN
 on:
   push:
     branches:
-    - master
+    - bstest
 
 jobs:
   upload:

--- a/.github/workflows/cdn.yml
+++ b/.github/workflows/cdn.yml
@@ -2,7 +2,7 @@ name: CDN
 on:
   push:
     branches:
-    - bstest
+    - master
 
 jobs:
   upload:

--- a/html/package.json
+++ b/html/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@runly/html",
   "private": true,
-  "version": "0.2.1-bstest-lazy-4",
+  "version": "0.2.1-bstest-lazy-5",
   "description": "Prebuilt script that can be dropped on any HTML page to include Runly components",
   "sideEffects": false,
   "scripts": {
     "lint": "eslint webpack.config.js src",
-    "bundle": "rimraf dist && webpack"
+    "bundle": "rimraf dist && webpack",
+    "watch": "rimraf dist && webpack --mode development --watch"
   },
   "repository": {
     "type": "git",

--- a/html/package.json
+++ b/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runly/html",
   "private": true,
-  "version": "0.2.1-bstest-lazy",
+  "version": "0.2.1-bstest-lazy-2",
   "description": "Prebuilt script that can be dropped on any HTML page to include Runly components",
   "sideEffects": false,
   "scripts": {

--- a/html/package.json
+++ b/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runly/html",
   "private": true,
-  "version": "0.2.1-lazy",
+  "version": "0.2.1-bstest-lazy",
   "description": "Prebuilt script that can be dropped on any HTML page to include Runly components",
   "sideEffects": false,
   "scripts": {

--- a/html/package.json
+++ b/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runly/html",
   "private": true,
-  "version": "0.2.1-bstest-lazy-3",
+  "version": "0.2.1-bstest-lazy-4",
   "description": "Prebuilt script that can be dropped on any HTML page to include Runly components",
   "sideEffects": false,
   "scripts": {

--- a/html/package.json
+++ b/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runly/html",
   "private": true,
-  "version": "0.2.1-bstest-lazy-7",
+  "version": "0.2.1",
   "description": "Prebuilt script that can be dropped on any HTML page to include Runly components",
   "sideEffects": false,
   "scripts": {
@@ -20,7 +20,7 @@
   },
   "homepage": "https://www.runly.io/docs/integration/js/html/",
   "dependencies": {
-    "@runly/react-bootstrap": "0.1.4-bstest",
+    "@runly/react-bootstrap": "^0.1.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },

--- a/html/package.json
+++ b/html/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://www.runly.io/docs/integration/js/html/",
   "dependencies": {
-    "@runly/react-bootstrap": "^0.1.3",
+    "@runly/react-bootstrap": "0.1.4-bstest",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },

--- a/html/package.json
+++ b/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runly/html",
   "private": true,
-  "version": "0.2.1-bstest-lazy-2",
+  "version": "0.2.1-bstest-lazy-3",
   "description": "Prebuilt script that can be dropped on any HTML page to include Runly components",
   "sideEffects": false,
   "scripts": {

--- a/html/package.json
+++ b/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runly/html",
   "private": true,
-  "version": "0.2.1-bstest-lazy-6",
+  "version": "0.2.1-bstest-lazy-7",
   "description": "Prebuilt script that can be dropped on any HTML page to include Runly components",
   "sideEffects": false,
   "scripts": {

--- a/html/package.json
+++ b/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runly/html",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.1-lazy",
   "description": "Prebuilt script that can be dropped on any HTML page to include Runly components",
   "sideEffects": false,
   "scripts": {

--- a/html/package.json
+++ b/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runly/html",
   "private": true,
-  "version": "0.2.1-bstest-lazy-5",
+  "version": "0.2.1-bstest-lazy-6",
   "description": "Prebuilt script that can be dropped on any HTML page to include Runly components",
   "sideEffects": false,
   "scripts": {

--- a/html/src/app.js
+++ b/html/src/app.js
@@ -9,6 +9,8 @@ async function initRunlyComponents() {
 	const React = await import("react");
 	const ReactDOM = await import("react-dom");
 
+	const { RunlyProvider } = RunlyComponents;
+
 	componentsToRender.forEach(el => {
 		const { runlyComponent, runlyToken, ...runlyProps } = el.dataset;
 

--- a/html/src/app.js
+++ b/html/src/app.js
@@ -1,40 +1,41 @@
-import React from "react";
-import { render } from "react-dom";
-
-import { RunlyProvider, RunProgress } from "@runly/react-bootstrap";
-
-const components = {
-	RunProgress
-};
-
 const componentsToRender = document.querySelectorAll("[data-runly-component]");
 
-componentsToRender.forEach(el => {
-	const { runlyComponent, runlyToken, ...runlyProps } = el.dataset;
+if (componentsToRender.length) {
+	initRunlyComponents();
+}
 
-	const ComponentToRender = components[runlyComponent];
+async function initRunlyComponents() {
+	const RunlyComponents = await import("@runly/react-bootstrap");
+	const React = await import("react");
+	const ReactDOM = await import("react-dom");
 
-	if (!ComponentToRender) {
-		throw new Error(
-			`Unrecognized runly component name: ${runlyComponent}. Check your data-runly-component attribute.`
+	componentsToRender.forEach(el => {
+		const { runlyComponent, runlyToken, ...runlyProps } = el.dataset;
+
+		const ComponentToRender = RunlyComponents[runlyComponent];
+
+		if (!ComponentToRender) {
+			throw new Error(
+				`Unrecognized runly component name: ${runlyComponent}. Check your data-runly-component attribute.`
+			);
+		}
+
+		if (!runlyToken) {
+			throw new Error(
+				`Missing required data attribute runly-token for ${runlyComponent} component. Make sure to include data-runly-token on your HTML elements.`
+			);
+		}
+
+		const props = convertRunlyProps(runlyProps);
+
+		ReactDOM.render(
+			<RunlyProvider accessToken={runlyToken}>
+				<ComponentToRender {...props} />
+			</RunlyProvider>,
+			el
 		);
-	}
-
-	if (!runlyToken) {
-		throw new Error(
-			`Missing required data attribute runly-token for ${runlyComponent} component. Make sure to include data-runly-token on your HTML elements.`
-		);
-	}
-
-	const props = convertRunlyProps(runlyProps);
-
-	render(
-		<RunlyProvider accessToken={runlyToken}>
-			<ComponentToRender {...props} />
-		</RunlyProvider>,
-		el
-	);
-});
+	});
+}
 
 function convertRunlyProps(runlyProps) {
 	const props = {};

--- a/html/src/app.js
+++ b/html/src/app.js
@@ -61,19 +61,19 @@ async function initRunlyComponents() {
 	);
 }
 
-function convertRunlyProps(runlyProps) {
+function convertRunlyProps(runlyProps, ns = "runly") {
 	const props = {};
 
 	for (let propName in runlyProps) {
-		if (propName.startsWith("runly")) {
-			props[convertAttrName(propName)] = runlyProps[propName];
+		if (propName.startsWith(ns)) {
+			props[convertAttrName(propName, ns)] = runlyProps[propName];
 		}
 	}
 
 	return props;
 }
 
-function convertAttrName(name, ns = "runly") {
+function convertAttrName(name, ns) {
 	const [, propName] = name.split(ns);
 	const [initial, ...rest] = propName;
 

--- a/html/src/app.js
+++ b/html/src/app.js
@@ -18,7 +18,7 @@ async function initRunlyComponents() {
 	const React = await import("react");
 	const ReactDOM = await import("react-dom");
 
-	const { RunlyProvider } = RunlyComponents;
+	const { RunlyReactBootstrapProvider } = RunlyComponents;
 
 	matchedEls.forEach(el => {
 		const {
@@ -50,13 +50,13 @@ async function initRunlyComponents() {
 	});
 
 	ReactDOM.render(
-		<RunlyProvider accessToken={runlyToken}>
+		<RunlyReactBootstrapProvider accessToken={runlyToken}>
 			<>
-				{componentsToRender.map(({ component: Component, el, ...props }) =>
-					ReactDOM.createPortal(<Component {...props} />, el)
-				)}
+				{componentsToRender.map(({ component: Component, el, ...props }) => {
+					return ReactDOM.createPortal(<Component {...props} />, el);
+				})}
 			</>
-		</RunlyProvider>,
+		</RunlyReactBootstrapProvider>,
 		rootEl
 	);
 }

--- a/html/src/app.js
+++ b/html/src/app.js
@@ -73,8 +73,9 @@ function convertRunlyProps(runlyProps) {
 	return props;
 }
 
-function convertAttrName(name) {
-	let propName = name.substring(5, name.length);
-	propName = propName.charAt(0).toLowerCase() + propName.substring(1);
-	return propName;
+function convertAttrName(name, ns = "runly") {
+	const [, propName] = name.split(ns);
+	const [initial, ...rest] = propName;
+
+	return `${initial.toLowerCase()}${rest.join("")}`;
 }

--- a/html/src/app.js
+++ b/html/src/app.js
@@ -47,6 +47,10 @@ async function initRunlyComponents() {
 		const props = convertRunlyProps(runlyProps);
 
 		componentsToRender.push({ component: ComponentToRender, el, ...props });
+
+		// Surprisingly enough createPortal doesn't,
+		// necessarily remove existing children
+		removeChildren(el);
 	});
 
 	ReactDOM.render(
@@ -79,3 +83,8 @@ function convertAttrName(name, ns) {
 
 	return `${initial.toLowerCase()}${rest.join("")}`;
 }
+const removeChildren = el => {
+	while (el.firstChild) {
+		el.removeChild(el.firstChild);
+	}
+};

--- a/html/webpack.config.js
+++ b/html/webpack.config.js
@@ -3,7 +3,7 @@ const version = require("./package.json").version;
 const path = require("path");
 
 module.exports = {
-	mode: "development",
+	mode: "production",
 	entry: "./src/app.js",
 	output: {
 		path: path.resolve(__dirname, "dist"),

--- a/html/webpack.config.js
+++ b/html/webpack.config.js
@@ -3,7 +3,7 @@ const version = require("./package.json").version;
 const path = require("path");
 
 module.exports = {
-	mode: "production",
+	mode: "development",
 	entry: "./src/app.js",
 	output: {
 		path: path.resolve(__dirname, "dist"),
@@ -11,7 +11,7 @@ module.exports = {
 		// to serve locally:
 		// npm run bundle && serve dist -l 8000
 		publicPath:
-			process.env.NODE_ENV !== "debug"
+			process.env.NODE_ENV === "production"
 				? `https://cdn.runly.io/v${version}/`
 				: "http://localhost:8000/"
 	},

--- a/html/webpack.config.js
+++ b/html/webpack.config.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-commonjs */
-
+const version = require("../package.json").version;
 const path = require("path");
 
 module.exports = {
@@ -7,7 +7,13 @@ module.exports = {
 	entry: "./src/app.js",
 	output: {
 		path: path.resolve(__dirname, "dist"),
-		filename: "runly.js"
+		filename: "runly.js",
+		// to serve locally:
+		// npm run bundle && serve dist -l 8000
+		publicPath:
+			process.env.NODE_ENV === "production"
+				? `https://cdn.runly.io/v${version}/`
+				: "http://localhost:8000/"
 	},
 	module: {
 		rules: [

--- a/html/webpack.config.js
+++ b/html/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
 		// to serve locally:
 		// npm run bundle && serve dist -l 8000
 		publicPath:
-			process.env.NODE_ENV === "production"
+			process.env.NODE_ENV !== "debug"
 				? `https://cdn.runly.io/v${version}/`
 				: "http://localhost:8000/"
 	},

--- a/html/webpack.config.js
+++ b/html/webpack.config.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-commonjs */
-const version = require("../package.json").version;
+const version = require("./package.json").version;
 const path = require("path");
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2536,6 +2536,24 @@
             "locate-path": "^3.0.0"
           }
         },
+        "global-modules": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+          "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+          "requires": {
+            "global-prefix": "^3.0.0"
+          }
+        },
+        "global-prefix": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+          "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+          "requires": {
+            "ini": "^1.3.5",
+            "kind-of": "^6.0.2",
+            "which": "^1.3.1"
+          }
+        },
         "globby": {
           "version": "8.0.2",
           "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
@@ -2613,9 +2631,9 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -2761,6 +2779,18 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "@runly/core": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@runly/core/-/core-0.1.3.tgz",
+      "integrity": "sha512-Dbhpt8yLvZqgdke0tdx+wRfAOCJ7elI8GtkQRRxoN8IdCpmGot8VMOGhFcTpIvuGvFoXYfLngm0GtHPjYsj85A==",
+      "requires": {
+        "@auth0/auth0-spa-js": "^1.6.5",
+        "@microsoft/signalr": "^3.1.2",
+        "lodash": "^4.17.15",
+        "react-fetch-hooks": "^3.0.0",
+        "urijs": "^1.19.2"
+      }
+    },
     "@runly/eslint-config": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@runly/eslint-config/-/eslint-config-1.0.1.tgz",
@@ -2777,6 +2807,16 @@
         "eslint-plugin-react": "^7.19.0",
         "eslint-plugin-react-functional-set-state": "^1.2.1",
         "eslint-plugin-react-hooks": "^2.5.1"
+      }
+    },
+    "@runly/react-bootstrap": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@runly/react-bootstrap/-/react-bootstrap-0.1.3.tgz",
+      "integrity": "sha512-SkctoZ0NfSQ+SG669QlCqFqdzdh9ZfPyR4yVqAX4CSiwsGRpHJN8Eo2Sav/Usqqg5sGg9PDE6cYU8euGnxHMaw==",
+      "requires": {
+        "@runly/core": "^0.1.3",
+        "accounting": "^0.4.1",
+        "lodash": "^4.17.15"
       }
     },
     "@sindresorhus/is": {
@@ -2881,9 +2921,9 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "@types/reach__router": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.3.tgz",
-      "integrity": "sha512-HTHMGJLdH3czgPP1nHF82y+TYLV1KSh1qYeezqHNDNuESBy55ij1LCn8jDYFeKCuAxm0gd9J25zyYy7mhOcgOw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.4.tgz",
+      "integrity": "sha512-DZgYfxUIlVSjvf0AvBbYNbpXLrTFNNpU1HrvCRbnMtx3nvGUUWC1/zlAe4dD4FCPFtc+LQuIPEsDiTb0zQkthg==",
       "requires": {
         "@types/history": "*",
         "@types/react": "*"
@@ -2919,20 +2959,50 @@
       "optional": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.26.0.tgz",
-      "integrity": "sha512-4yUnLv40bzfzsXcTAtZyTjbiGUXMrcIJcIMioI22tSOyAxpdXiZ4r7YQUU8Jj6XXrLz9d5aMHPQf5JFR7h27Nw==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.27.0.tgz",
+      "integrity": "sha512-/my+vVHRN7zYgcp0n4z5A6HAK7bvKGBiswaM5zIlOQczsxj/aiD7RcgD+dvVFuwFaGh5+kM7XA6Q6PN0bvb1tw==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.26.0",
+        "@typescript-eslint/experimental-utils": "2.27.0",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
         "tsutils": "^3.17.1"
       },
       "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "2.27.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.27.0.tgz",
+          "integrity": "sha512-vOsYzjwJlY6E0NJRXPTeCGqjv5OHgRU1kzxHKWJVPjDYGbPgLudBXjIlc+OD1hDBZ4l1DLbOc5VjofKahsu9Jw==",
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/typescript-estree": "2.27.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^2.0.0"
+          }
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "2.27.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.27.0.tgz",
+          "integrity": "sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==",
+          "requires": {
+            "debug": "^4.1.1",
+            "eslint-visitor-keys": "^1.1.0",
+            "glob": "^7.1.6",
+            "is-glob": "^4.0.1",
+            "lodash": "^4.17.15",
+            "semver": "^6.3.0",
+            "tsutils": "^3.17.1"
+          }
+        },
         "regexpp": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
-          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g=="
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+          "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -2940,6 +3010,7 @@
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.26.0.tgz",
       "integrity": "sha512-RELVoH5EYd+JlGprEyojUv9HeKcZqF7nZUGSblyAw1FwOGNnmQIU8kxJ69fttQvEwCsX5D6ECJT8GTozxrDKVQ==",
+      "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
         "@typescript-eslint/typescript-estree": "2.26.0",
@@ -2948,20 +3019,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.26.0.tgz",
-      "integrity": "sha512-+Xj5fucDtdKEVGSh9353wcnseMRkPpEAOY96EEenN7kJVrLqy/EVwtIh3mxcUz8lsFXW1mT5nN5vvEam/a5HiQ==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.27.0.tgz",
+      "integrity": "sha512-HFUXZY+EdwrJXZo31DW4IS1ujQW3krzlRjBrFRrJcMDh0zCu107/nRfhk/uBasO8m0NVDbBF5WZKcIUMRO7vPg==",
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.26.0",
-        "@typescript-eslint/typescript-estree": "2.26.0",
+        "@typescript-eslint/experimental-utils": "2.27.0",
+        "@typescript-eslint/typescript-estree": "2.27.0",
         "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "2.27.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.27.0.tgz",
+          "integrity": "sha512-vOsYzjwJlY6E0NJRXPTeCGqjv5OHgRU1kzxHKWJVPjDYGbPgLudBXjIlc+OD1hDBZ4l1DLbOc5VjofKahsu9Jw==",
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/typescript-estree": "2.27.0",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^2.0.0"
+          }
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "2.27.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.27.0.tgz",
+          "integrity": "sha512-t2miCCJIb/FU8yArjAvxllxbTiyNqaXJag7UOpB5DVoM3+xnjeOngtqlJkLRnMtzaRcJhe3CIR9RmL40omubhg==",
+          "requires": {
+            "debug": "^4.1.1",
+            "eslint-visitor-keys": "^1.1.0",
+            "glob": "^7.1.6",
+            "is-glob": "^4.0.1",
+            "lodash": "^4.17.15",
+            "semver": "^6.3.0",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "@typescript-eslint/typescript-estree": {
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.26.0.tgz",
       "integrity": "sha512-3x4SyZCLB4zsKsjuhxDLeVJN6W29VwBnYpCsZ7vIdPel9ZqLfIZJgJXO47MNUkurGpQuIBALdPQKtsSnWpE1Yg==",
+      "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "eslint-visitor-keys": "^1.1.0",
@@ -2975,7 +3079,8 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -3623,17 +3728,24 @@
       "optional": true
     },
     "autoprefixer": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.5.tgz",
-      "integrity": "sha512-URo6Zvt7VYifomeAfJlMFnYDhow1rk2bufwkbamPEAtQFcL11moLk4PnR7n9vlu7M+BkXAZkHFA0mIcY7tjQFg==",
+      "version": "9.7.6",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.6.tgz",
+      "integrity": "sha512-F7cYpbN7uVVhACZTeeIeealwdGM6wMtfWARVLTy5xmKtgVdBNJvbDRoCK3YO1orcs7gv/KwYlb3iXwu9Ug9BkQ==",
       "requires": {
-        "browserslist": "^4.11.0",
-        "caniuse-lite": "^1.0.30001036",
+        "browserslist": "^4.11.1",
+        "caniuse-lite": "^1.0.30001039",
         "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
         "postcss": "^7.0.27",
         "postcss-value-parser": "^4.0.3"
+      },
+      "dependencies": {
+        "caniuse-lite": {
+          "version": "1.0.30001039",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz",
+          "integrity": "sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q=="
+        }
       }
     },
     "aws-sign2": {
@@ -5586,14 +5698,6 @@
         "to-file": "^0.2.0"
       },
       "dependencies": {
-        "expand-tilde": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-          "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-          "requires": {
-            "os-homedir": "^1.0.1"
-          }
-        },
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -5610,26 +5714,6 @@
             "is-glob": "^2.0.0"
           }
         },
-        "global-modules": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-          "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-          "requires": {
-            "global-prefix": "^0.1.4",
-            "is-windows": "^0.2.0"
-          }
-        },
-        "global-prefix": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-          "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-          "requires": {
-            "homedir-polyfill": "^1.0.0",
-            "ini": "^1.3.4",
-            "is-windows": "^0.2.0",
-            "which": "^1.2.12"
-          }
-        },
         "is-extglob": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
@@ -5641,28 +5725,6 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
             "is-extglob": "^1.0.0"
-          }
-        },
-        "is-windows": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
-        },
-        "resolve-dir": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-          "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-          "requires": {
-            "expand-tilde": "^1.2.2",
-            "global-modules": "^0.2.3"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "requires": {
-            "isexe": "^2.0.0"
           }
         }
       }
@@ -5736,9 +5798,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -7894,11 +7956,11 @@
       }
     },
     "expand-tilde": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+      "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "os-homedir": "^1.0.1"
       }
     },
     "express": {
@@ -8373,9 +8435,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -8425,6 +8487,55 @@
         "is-glob": "^4.0.0",
         "micromatch": "^3.0.4",
         "resolve-dir": "^1.0.1"
+      },
+      "dependencies": {
+        "expand-tilde": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+          "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+          "requires": {
+            "homedir-polyfill": "^1.0.1"
+          }
+        },
+        "global-modules": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+          "requires": {
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
+          }
+        },
+        "global-prefix": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+          "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+          "requires": {
+            "expand-tilde": "^2.0.2",
+            "homedir-polyfill": "^1.0.1",
+            "ini": "^1.3.4",
+            "is-windows": "^1.0.1",
+            "which": "^1.2.14"
+          }
+        },
+        "resolve-dir": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+          "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+          "requires": {
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "flat": {
@@ -9106,9 +9217,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.20.12",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.20.12.tgz",
-      "integrity": "sha512-HoyjJA432ZUKOgkzsOSEdSbo3Vhi3lhr5uw8JnebO4S9Cqc6J2kw9HNASwtYFGzZVClGrsYwXVaLcOnSKtZmxA==",
+      "version": "2.20.13",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.20.13.tgz",
+      "integrity": "sha512-hPzmHSWhInIlY4Lg6hSrFlCxcITCsTs9QM5OhmmFtWDVY3fAr/MsVH1NVZJuY+rTFYtvk5hO284dOBMGcHtUww==",
       "requires": {
         "@babel/code-frame": "^7.8.3",
         "@babel/core": "^7.8.7",
@@ -9480,10 +9591,26 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
+        "is-relative": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+          "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+          "requires": {
+            "is-unc-path": "^1.0.0"
+          }
+        },
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "is-unc-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+          "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+          "requires": {
+            "unc-path-regex": "^0.1.2"
+          }
         },
         "locate-path": {
           "version": "3.0.0",
@@ -9529,9 +9656,9 @@
           "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -10371,23 +10498,37 @@
       }
     },
     "global-modules": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+      "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
       "requires": {
-        "global-prefix": "^3.0.0"
+        "global-prefix": "^0.1.4",
+        "is-windows": "^0.2.0"
+      },
+      "dependencies": {
+        "is-windows": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+        }
       }
     },
     "global-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+      "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
       "requires": {
-        "ini": "^1.3.5",
-        "kind-of": "^6.0.2",
-        "which": "^1.3.1"
+        "homedir-polyfill": "^1.0.0",
+        "ini": "^1.3.4",
+        "is-windows": "^0.2.0",
+        "which": "^1.2.12"
       },
       "dependencies": {
+        "is-windows": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+        },
         "which": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -11648,22 +11789,6 @@
         "is-windows": "^0.2.0"
       },
       "dependencies": {
-        "is-relative": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-          "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
-          "requires": {
-            "is-unc-path": "^0.1.1"
-          }
-        },
-        "is-unc-path": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-          "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
-          "requires": {
-            "unc-path-regex": "^0.1.0"
-          }
-        },
         "is-windows": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
@@ -11964,11 +12089,11 @@
       }
     },
     "is-relative": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
       "requires": {
-        "is-unc-path": "^1.0.0"
+        "is-unc-path": "^0.1.1"
       }
     },
     "is-relative-url": {
@@ -12043,11 +12168,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-unc-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
       "requires": {
-        "unc-path-regex": "^0.1.2"
+        "unc-path-regex": "^0.1.0"
       }
     },
     "is-utf8": {
@@ -12740,62 +12865,12 @@
         "resolve-dir": "^0.1.0"
       },
       "dependencies": {
-        "expand-tilde": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-          "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-          "requires": {
-            "os-homedir": "^1.0.1"
-          }
-        },
         "extend-shallow": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
-          }
-        },
-        "global-modules": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-          "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-          "requires": {
-            "global-prefix": "^0.1.4",
-            "is-windows": "^0.2.0"
-          }
-        },
-        "global-prefix": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-          "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-          "requires": {
-            "homedir-polyfill": "^1.0.0",
-            "ini": "^1.3.4",
-            "is-windows": "^0.2.0",
-            "which": "^1.2.12"
-          }
-        },
-        "is-windows": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
-        },
-        "resolve-dir": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-          "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-          "requires": {
-            "expand-tilde": "^1.2.2",
-            "global-modules": "^0.2.3"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "requires": {
-            "isexe": "^2.0.0"
           }
         }
       }
@@ -15467,6 +15542,14 @@
             "original": ">=0.0.5"
           }
         },
+        "expand-tilde": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+          "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+          "requires": {
+            "homedir-polyfill": "^1.0.1"
+          }
+        },
         "external-editor": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
@@ -15607,6 +15690,15 @@
           "integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
           "requires": {
             "minimatch": "3.0.3"
+          }
+        },
+        "resolve-dir": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+          "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+          "requires": {
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
           }
         },
         "shebang-command": {
@@ -16115,44 +16207,12 @@
       }
     },
     "resolve-dir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+      "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
-      },
-      "dependencies": {
-        "global-modules": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-          "requires": {
-            "global-prefix": "^1.0.1",
-            "is-windows": "^1.0.1",
-            "resolve-dir": "^1.0.0"
-          }
-        },
-        "global-prefix": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-          "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-          "requires": {
-            "expand-tilde": "^2.0.2",
-            "homedir-polyfill": "^1.0.1",
-            "ini": "^1.3.4",
-            "is-windows": "^1.0.1",
-            "which": "^1.2.14"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
+        "expand-tilde": "^1.2.2",
+        "global-modules": "^0.2.3"
       }
     },
     "resolve-from": {
@@ -16991,9 +17051,9 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
     },
     "spdy": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.1.tgz",
-      "integrity": "sha512-HeZS3PBdMA+sZSu0qwpCxl3DeALD5ASx8pAX0jZdKXSpPWbQ6SYGnlg3BBmYLx5LtiZrmkAZfErCm2oECBcioA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+      "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
       "requires": {
         "debug": "^4.1.0",
         "handle-thing": "^2.0.0",
@@ -17319,9 +17379,9 @@
       "dev": true
     },
     "strip-json-comments": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w=="
     },
     "strong-log-transformer": {
       "version": "2.1.0",
@@ -18696,6 +18756,24 @@
             "locate-path": "^3.0.0"
           }
         },
+        "global-modules": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+          "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+          "requires": {
+            "global-prefix": "^3.0.0"
+          }
+        },
+        "global-prefix": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+          "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+          "requires": {
+            "ini": "^1.3.5",
+            "kind-of": "^6.0.2",
+            "which": "^1.3.1"
+          }
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -18729,9 +18807,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -18986,9 +19064,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "requires": {
             "p-try": "^2.0.0"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2779,18 +2779,6 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
-    "@runly/core": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@runly/core/-/core-0.1.3.tgz",
-      "integrity": "sha512-Dbhpt8yLvZqgdke0tdx+wRfAOCJ7elI8GtkQRRxoN8IdCpmGot8VMOGhFcTpIvuGvFoXYfLngm0GtHPjYsj85A==",
-      "requires": {
-        "@auth0/auth0-spa-js": "^1.6.5",
-        "@microsoft/signalr": "^3.1.2",
-        "lodash": "^4.17.15",
-        "react-fetch-hooks": "^3.0.0",
-        "urijs": "^1.19.2"
-      }
-    },
     "@runly/eslint-config": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@runly/eslint-config/-/eslint-config-1.0.1.tgz",
@@ -2807,16 +2795,6 @@
         "eslint-plugin-react": "^7.19.0",
         "eslint-plugin-react-functional-set-state": "^1.2.1",
         "eslint-plugin-react-hooks": "^2.5.1"
-      }
-    },
-    "@runly/react-bootstrap": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@runly/react-bootstrap/-/react-bootstrap-0.1.3.tgz",
-      "integrity": "sha512-SkctoZ0NfSQ+SG669QlCqFqdzdh9ZfPyR4yVqAX4CSiwsGRpHJN8Eo2Sav/Usqqg5sGg9PDE6cYU8euGnxHMaw==",
-      "requires": {
-        "@runly/core": "^0.1.3",
-        "accounting": "^0.4.1",
-        "lodash": "^4.17.15"
       }
     },
     "@sindresorhus/is": {

--- a/react-bootstrap/package.json
+++ b/react-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runly/react-bootstrap",
-  "version": "0.1.3",
+  "version": "0.1.4-bstest",
   "description": "Bootstrap-styled react components to connect to Runly",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/react-bootstrap/package.json
+++ b/react-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runly/react-bootstrap",
-  "version": "0.1.4-bstest",
+  "version": "0.1.3",
   "description": "Bootstrap-styled react components to connect to Runly",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/react-bootstrap/src/index.js
+++ b/react-bootstrap/src/index.js
@@ -1,7 +1,9 @@
 import React, { useEffect, createContext, useContext } from "react";
+
+import { RunlyProvider } from "@runly/core";
+
 export { default as RunProgress } from "./progress";
 export { default as OrgChooser } from "./org-chooser";
-import { RunlyProvider } from "@runly/core";
 
 const RunlyReactBootstrapContext = createContext();
 
@@ -17,14 +19,14 @@ const bs4test = () => {
 		el.setAttribute("class", "d-inline");
 
 		document.body.appendChild(el);
-		result = (getComputedStyle(el) === "inline");
+		result = getComputedStyle(el) === "inline";
 		document.body.removeChild(el);
 	}
 
 	return result;
-}
+};
 
-const RunlyReactBootstrapProvider = ({props,...children}) => {
+export const RunlyReactBootstrapProvider = ({ props, ...children }) => {
 	useEffect(() => {
 		if (typeof hasbs4 === "undefined") {
 			hasbs4 = bs4test();
@@ -44,11 +46,11 @@ const RunlyReactBootstrapProvider = ({props,...children}) => {
 			)}
 		</RunlyProvider>
 	);
-}
+};
 
-const useBsConfig = () => {
+export const useBsConfig = () => {
 	const cfg = useContext(RunlyReactBootstrapContext);
-}
+	return cfg;
+};
 
 // for convenience
-export { RunlyProvider } from "@runly/core";

--- a/react-bootstrap/src/index.js
+++ b/react-bootstrap/src/index.js
@@ -1,5 +1,54 @@
+import React, { useEffect, createContext, useContext } from "react";
 export { default as RunProgress } from "./progress";
 export { default as OrgChooser } from "./org-chooser";
+import { RunlyProvider } from "@runly/core";
+
+const RunlyReactBootstrapContext = createContext();
+
+let hasbs4 = undefined;
+
+const bs4test = () => {
+	let result = null;
+
+	if (document) {
+		const el = document.createElement("div");
+
+		el.setAttribute("style", "display: block;");
+		el.setAttribute("class", "d-inline");
+
+		document.body.appendChild(el);
+		result = (getComputedStyle(el) === "inline");
+		document.body.removeChild(el);
+	}
+
+	return result;
+}
+
+const RunlyReactBootstrapProvider = ({props,...children}) => {
+	useEffect(() => {
+		if (typeof hasbs4 === "undefined") {
+			hasbs4 = bs4test();
+		}
+	}, []);
+
+	return (
+		<RunlyProvider {...props}>
+			{runlyProps => (
+				<RunlyReactBootstrapContext.Provider
+					{...props}
+					{...runlyProps}
+					hasbs4={hasbs4}
+				>
+					{children}
+				</RunlyReactBootstrapContext.Provider>
+			)}
+		</RunlyProvider>
+	);
+}
+
+const useBsConfig = () => {
+	const cfg = useContext(RunlyReactBootstrapContext);
+}
 
 // for convenience
 export { RunlyProvider } from "@runly/core";

--- a/react-bootstrap/src/index.js
+++ b/react-bootstrap/src/index.js
@@ -17,14 +17,14 @@ const bs4test = () => {
 		el.setAttribute("class", "d-inline");
 
 		document.body.appendChild(el);
-		result = getComputedStyle(el) === "inline";
+		result = getComputedStyle(el).display === "inline";
 		document.body.removeChild(el);
 	}
 
 	return result;
 };
 
-export const RunlyReactBootstrapProvider = ({ props, ...children }) => {
+export const RunlyReactBootstrapProvider = ({ children, ...props }) => {
 	const [hasBs4, setHasBs4] = useState(null);
 	useEffect(() => {
 		if (hasBs4 === null) {
@@ -34,10 +34,7 @@ export const RunlyReactBootstrapProvider = ({ props, ...children }) => {
 
 	return (
 		<RunlyProvider {...props}>
-			<RunlyReactBootstrapContext.Provider
-				{...props}
-				value={{ hasBs4, setHasBs4 }}
-			>
+			<RunlyReactBootstrapContext.Provider value={{ hasBs4, setHasBs4 }}>
 				{children}
 			</RunlyReactBootstrapContext.Provider>
 		</RunlyProvider>

--- a/react-bootstrap/src/index.js
+++ b/react-bootstrap/src/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, createContext, useContext } from "react";
+import React, { useEffect, useState, createContext, useContext } from "react";
 
 import { RunlyProvider } from "@runly/core";
 
@@ -6,8 +6,6 @@ export { default as RunProgress } from "./progress";
 export { default as OrgChooser } from "./org-chooser";
 
 const RunlyReactBootstrapContext = createContext();
-
-let hasbs4 = undefined;
 
 const bs4test = () => {
 	let result = null;
@@ -27,23 +25,21 @@ const bs4test = () => {
 };
 
 export const RunlyReactBootstrapProvider = ({ props, ...children }) => {
+	const [hasBs4, setHasBs4] = useState(null);
 	useEffect(() => {
-		if (typeof hasbs4 === "undefined") {
-			hasbs4 = bs4test();
+		if (hasBs4 === null) {
+			setHasBs4(bs4test());
 		}
-	}, []);
+	}, [hasBs4]);
 
 	return (
 		<RunlyProvider {...props}>
-			{runlyProps => (
-				<RunlyReactBootstrapContext.Provider
-					{...props}
-					{...runlyProps}
-					hasbs4={hasbs4}
-				>
-					{children}
-				</RunlyReactBootstrapContext.Provider>
-			)}
+			<RunlyReactBootstrapContext.Provider
+				{...props}
+				value={{ hasBs4, setHasBs4 }}
+			>
+				{children}
+			</RunlyReactBootstrapContext.Provider>
 		</RunlyProvider>
 	);
 };


### PR DESCRIPTION
This creates a bundle with code splitting which will only load the hefty chunks for consumers of the HTML API if matching data attributes are found. Additionally, now we use a single `ReactDOM.render` call and use `createPortal` to take care of rendering into disparate nodes if the user is binding in multiple places on the page. This means all runly components on the page can share a single context. Added to the context in the default case now, we also have a test for the presence of bootstrap 4 utility styles, which we can use to lazy load a subset of bootstrap styles if the global sheet is not present, noob-proofing the example app even further.